### PR TITLE
fix(parser): extract values from allowed properieties if type is temp…

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -285,6 +285,10 @@ class Parser {
                     if (_.includes(supportedOptions, prop.key.name)) {
                         if (prop.value.type === 'Literal') {
                             options[prop.key.name] = prop.value.value;
+                        } else if (prop.value.type === 'TemplateLiteral') {
+                            options[prop.key.name] = prop.value.quasis.map(function(element) {
+                                return element.value.cooked;
+                            }).join('');
                         } else {
                             // Unable to get value of the property
                             options[prop.key.name] = '';

--- a/test/fixtures/template-literals.js
+++ b/test/fixtures/template-literals.js
@@ -1,0 +1,1 @@
+i18n.t('property in template literals', {defaultValue: `property in template literals`});

--- a/test/parser.js
+++ b/test/parser.js
@@ -525,3 +525,29 @@ test('parser.toJSON({ sort: true, space: 2 })', (t) => {
     t.same(parser.toJSON({ sort: true, space: 2 }), wanted);
     t.end();
 });
+
+test('Extract properties from template literals', (t) => {
+    const parser = new Parser({
+        defaultValue: function(lng, ns, key) {
+            if (lng === 'en') {
+                return key;
+            }
+            return '__NOT_TRANSLATED__';
+        },
+        keySeparator: false,
+        nsSeparator: false
+    });
+    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/template-literals.js'), 'utf8');
+    const wanted = {
+        "en": {
+            "translation": {
+                "property in template literals": "property in template literals",
+            }
+        }
+    };
+
+    parser.parseFuncFromString(content);
+    t.same(parser.get(), wanted);
+
+    t.end();
+});


### PR DESCRIPTION
…late literal

Makes it possible to use multiline strings in allowed properties.

fyi @herschel666,  paired with @tobiasBales