### PR TITLE
Slim down NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-/.nyc_output
-/coverage
-/output

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "crc32",
     "md5"
   ],
+  "files": [
+    "lib",
+    "tasks"
+  ],
   "dependencies": {
     "esprima": "^4.0.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This PR slims down the NPM package. See http://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish for reasoning.

```
$ npm pack
i18next-scanner-2.0.0.tgz

$ tar tvf i18next-scanner-2.0.0.tgz 
-rw-rw-r-- 1000/1000      1797 2017-10-15 13:32 package/package.json
-rw-rw-r-- 1000/1000     17235 2017-10-15 13:30 package/README.md
-rw-rw-r-- 1000/1000      1082 2017-10-15 13:30 package/LICENSE
-rw-rw-r-- 1000/1000       492 2017-10-15 13:32 package/lib/ensure-array.js
-rw-rw-r-- 1000/1000      3368 2017-10-15 13:32 package/lib/index.js
-rw-rw-r-- 1000/1000      2143 2017-10-15 13:32 package/lib/jsx-parser.js
-rw-rw-r-- 1000/1000     30445 2017-10-15 13:32 package/lib/parser.js
-rw-rw-r-- 1000/1000       709 2017-10-15 13:30 package/tasks/index.js
```