### PR TITLE
Use htmlparser2 to parse JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
   ],
   "dependencies": {
     "esprima": "^4.0.0",
+    "htmlparser2": "^3.9.2",
     "lodash": "^4.17.4",
-    "parse5": "^3.0.2",
+    "parse5": "^3.0.3",
     "sortobject": "^1.1.1",
     "through2": "^2.0.3",
     "vinyl": "^2.1.0",

--- a/test/jsx-parser.js
+++ b/test/jsx-parser.js
@@ -66,8 +66,23 @@ test('JSX Nested expression', (t) => {
 });
 
 
+test('JSX child node', (t) => {
+    const ast = parseJSX('I agree to the <Link>terms</Link>.')
+    t.same(ast.length, 3)
+    t.same(ast[0].nodeName, '#text')
+    t.same(ast[1].nodeName, 'Link')
+    t.same(ast[1].childNodes.length, 1)
+    t.same(ast[1].childNodes[0].nodeName, '#text')
+    t.same(ast[1].childNodes[0].value, 'terms')
+    t.same(ast[2].nodeName, '#text')
+    t.same(ast[2].value, '.')
+    t.end();
+});
+
 test('JSX to i18next', (t) => {
     t.same(jsxToText('Basic text'), 'Basic text')
     t.same(jsxToText('Hello, {{name}}'), 'Hello, <1>{{name}}</1>')
+    t.same(jsxToText('I agree to the <Link>terms</Link>.'), 'I agree to the <1>terms</1>.')
+    t.same(jsxToText('One &amp; two'), 'One & two')
     t.end()
 })


### PR DESCRIPTION
parse5 will enforce HTML policies, such as forcing empty elements to have no text. This will break valid JSX using components with names like `Link`. To fix this switch to the XML parser mode of htmlparser2.

This fixes #51 