### PR TITLE
Fix the installation of cli.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "md5"
   ],
   "files": [
+    "bin",
     "lib",
     "tasks"
   ],


### PR DESCRIPTION
Hello, @cheton 

I'm trying to install the latest release of i18next-scanner without success:

```
$ npm install i18next-scanner
...
npm ERR! enoent ENOENT: no such file or directory, chmod '/tmp/container/node_modules/i18next-scanner/bin/cli.js'
npm ERR! enoent ENOENT: no such file or directory, chmod '/tmp/container/node_modules/i18next-scanner/bin/cli.js'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 
```

I could install it if I ignore the bin links:

```
$ npm install i18next-scanner --no-bin-links
```

I think you miss the bin folder to be added to the package :)

I added it but I don't know if we need to test it, or how to test it. Do you have any suggestion?