### PR TITLE
Improve handling of default values

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -635,8 +635,14 @@ class Parser {
                         }
                         this.log(`i18next-scanner: Added a new translation key { ${chalk.yellow(JSON.stringify(resKey))}: ${chalk.yellow(JSON.stringify(resLoad[resKey]))} } to ${chalk.yellow(JSON.stringify(this.formatResourceLoadPath(lng, ns)))}`);
                     } else if (options.defaultValue) {
-                        // Use `options.defaultValue` if specified
-                        resLoad[resKey] = options.defaultValue;
+                        if (!resLoad[resKey]) {
+                            // Use `options.defaultValue` if specified
+                            resLoad[resKey] = options.defaultValue;
+                        } else if (resLoad[resKey] !== options.defaultValue) {
+                            // We already had a different default.
+                            const k = chalk.yellow(JSON.stringify(resKey));
+                            this.log(`i18next-scanner: Translation key ${k} has multiple different default values. Using first default`);
+                        }
                     }
 
                     resScan[resKey] = resLoad[resKey];

--- a/src/parser.js
+++ b/src/parser.js
@@ -634,6 +634,9 @@ class Parser {
                                 : defaultValue;
                         }
                         this.log(`i18next-scanner: Added a new translation key { ${chalk.yellow(JSON.stringify(resKey))}: ${chalk.yellow(JSON.stringify(resLoad[resKey]))} } to ${chalk.yellow(JSON.stringify(this.formatResourceLoadPath(lng, ns)))}`);
+                    } else if (options.defaultValue) {
+                        // Use `options.defaultValue` if specified
+                        resLoad[resKey] = options.defaultValue;
                     }
 
                     resScan[resKey] = resLoad[resKey];

--- a/test/parser.js
+++ b/test/parser.js
@@ -3,7 +3,19 @@ import path from 'path';
 import { test } from 'tap';
 import { Parser } from '../src';
 
-const defaults = {};
+test('set merges defaults', (t) => {
+    const parser = new Parser({
+        ns: ['translation']
+    });
+    parser.set('key1', { defaultValue: 'Default text' });
+    parser.set('key1');
+    t.same(parser.get('key1'), 'Default text');
+
+    parser.set('key2');
+    parser.set('key2', { defaultValue: 'Default text' });
+    t.same(parser.get('key2'), 'Default text');
+    t.end();
+});
 
 test('Skip undefined namespace', (t) => {
     const parser = new Parser({

--- a/test/parser.js
+++ b/test/parser.js
@@ -17,6 +17,21 @@ test('set merges defaults', (t) => {
     t.end();
 });
 
+test('set warns about conflicting defaults', (t) => {
+    const parser = new Parser({
+        ns: ['translation']
+    });
+    let logText;
+    parser.log = (msg) => {
+        logText = msg;
+    };
+    parser.set('key', { defaultValue: 'Default text' });
+    parser.set('key', { defaultValue: 'Another text' });
+    t.same(parser.get('key'), 'Default text');
+    t.match(logText, /different default/);
+    t.end();
+});
+
 test('Skip undefined namespace', (t) => {
     const parser = new Parser({
         ns: ['translation']


### PR DESCRIPTION
This PR tries to improve the handling of default values. Specifically it does two things:

* if you use the same key twice, but don't supply a default on the first occurrence any defaultValue set on other instances was ignored.
* if you use a different default value for the same key in multiple places i18next-scanner will warn you.