### PR TITLE
Add missing dependency 'commander'

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "tasks"
   ],
   "dependencies": {
+    "commander": "^2.11.0",
     "esprima": "^4.0.0",
     "gulp-sort": "^2.0.0",
     "htmlparser2": "^3.9.2",


### PR DESCRIPTION
i18next-scanner/bin/cli.js needs this package.

```javascript
var program = require('commander');
```