### PR TITLE
Move 'chalk' dependency to dependencies instead of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "tasks"
   ],
   "dependencies": {
+    "chalk": "^2.3.0",
     "commander": "^2.11.0",
     "esprima": "^4.0.0",
     "gulp-sort": "^2.0.0",
@@ -64,7 +65,6 @@
     "babel-eslint": "^8.0.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "chalk": "^2.3.0",
     "coveralls": "^2.13.1",
     "eslint": "^4.10.0",
     "eslint-config-trendmicro": "^1.1.0",


### PR DESCRIPTION
Dependency 'chalk' is not only needed during development time, so moved to 'dependencies'.