### PR TITLE
Iterates through all of the JSX element attributes to filter JSXElement values (#90)

### DIFF
--- a/test/fixtures/trans.jsx
+++ b/test/fixtures/trans.jsx
@@ -1,5 +1,7 @@
 import { Fragment } from 'react';
 
+const Component = (props) => props.children;
+
 const mycomp = () => (
     <Fragment>
         <Fragment>
@@ -77,6 +79,39 @@ const mycomp = () => (
             <Trans defaults="The component might be self-closing" />
             <Trans defaults="Some <0>{variable}</0>" />
             <Trans defaults="Hello <1>{{planet}}</1>!" tOptions={{planet: "World"}} components={[<strong>stuff</strong>]} />
+        </Fragment>
+        <Fragment>
+            <Component
+                render={(
+                    <Trans>translation from props</Trans>
+                )}
+            />
+            <Component
+                render={(
+                    <Component
+                        render={(
+                            <Trans>translation from nested props</Trans>
+                        )}
+                    />
+                )}
+            />
+            <Component
+                render={(
+                    <Component
+                        render={(
+                            <Component
+                                render={(
+                                    <Component
+                                        render={(
+                                            <Trans>translation from deeply nested props</Trans>
+                                        )}
+                                    />
+                                )}
+                            />
+                        )}
+                    />
+                )}
+            />
         </Fragment>
         <Fragment>
             <I18n __t="mykey">A wrapper component with key</I18n>

--- a/test/parser.js
+++ b/test/parser.js
@@ -109,7 +109,7 @@ test('Parse Trans components', (t) => {
         fallbackLng: 'en'
     });
 
-    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/app.jsx'), 'utf-8');
+    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/trans.jsx'), 'utf-8');
     parser.parseTransFromString(content);
     t.same(parser.get(), {
         en: {
@@ -149,6 +149,11 @@ test('Parse Trans components', (t) => {
                 "The component might be self-closing": "The component might be self-closing",
                 "Some <0>{variable}</0>": "Some <0>{variable}</0>",
                 "Hello <1>{{planet}}</1>!": "Hello <1>{{planet}}</1>!",
+
+                // props
+                "translation from props": "translation from props",
+                "translation from nested props": "translation from nested props",
+                "translation from deeply nested props": "translation from deeply nested props"
             }
         }
     });
@@ -168,7 +173,7 @@ test('Parse Trans components with fallback key', (t) => {
         fallbackLng: 'en'
     });
 
-    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/app.jsx'), 'utf-8');
+    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/trans.jsx'), 'utf-8');
     parser.parseTransFromString(content);
     t.same(parser.get(), {
         en: {
@@ -208,6 +213,11 @@ test('Parse Trans components with fallback key', (t) => {
                 "7551746c2d33a1d0a24658c22821c8700fa58a0d": "Hello <1>{{planet}}</1>!",
                 "253344d83465052dd6573c8c0abcd76f02fc3a97": "Some <0>{variable}</0>",
                 "7e514af8f77b74e74f86dc22a2cb173680462e34": "The component might be self-closing",
+
+                // props
+                "c38f91deba88fc3bb582cc73dc658210324b01ec": "translation from props",
+                "5bf216b4068991e3a2f5e55ae36c03add490a63f": "translation from nested props",
+                "6fadff01c49d0ebe862a3aa33688735c03728197": "translation from deeply nested props"
             }
         }
     });
@@ -227,7 +237,7 @@ test('Parse wrapped Trans components', (t) => {
         fallbackLng: 'en',
     });
 
-    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/app.jsx'), 'utf-8');
+    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/trans.jsx'), 'utf-8');
     parser.parseTransFromString(content);
     t.same(parser.get(), {
         en: {

--- a/test/transform-stream.js
+++ b/test/transform-stream.js
@@ -167,7 +167,7 @@ test('[Trans Component] fallbackKey', function(t) {
         keySeparator: '.' // Specify the keySeparator for this test to make sure the fallbackKey won't be separated
     });
 
-    gulp.src('test/fixtures/**/app.jsx')
+    gulp.src('test/fixtures/**/trans.jsx')
         .pipe(scanner(options))
         .on('end', function() {
             t.end();
@@ -213,6 +213,11 @@ test('[Trans Component] fallbackKey', function(t) {
                     "The component might be self-closing": "The component might be self-closing",
                     "Some <0>{variable}</0>": "Some <0>{variable}</0>",
                     "Hello <1>{{planet}}</1>!": "Hello <1>{{planet}}</1>!",
+
+                    // props
+                    "translation from props": "translation from props",
+                    "translation from nested props": "translation from nested props",
+                    "translation from deeply nested props": "translation from deeply nested props"
                 };
                 t.same(found, wanted);
             }


### PR DESCRIPTION
This PR fixes #90 where translation within props cannot be correctly parsed:

```jsx
<Component render={<Trans>translation from props</Trans>} />
```