### PR TITLE
Fix debug warning in case of trailing comma in function

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -358,7 +358,7 @@ class Parser {
                 }
 
                 try {
-                    const syntax = parse('(' + code + ')');
+                    const syntax = code.trim() !== '' ? parse('(' + code + ')') : {};
                     const props = _.get(syntax, 'body[0].expression.properties') || [];
                     // http://i18next.com/docs/options/
                     const supportedOptions = [

--- a/test/parser.js
+++ b/test/parser.js
@@ -925,3 +925,29 @@ test('Custom keySeparator and nsSeparator', (t) => {
 
     t.end();
 });
+
+test('Should accept trailing comma in functions', (t) => {
+    const content = `
+        i18next.t(
+            'friend',
+        )
+    `
+    class ParserMock extends Parser {
+        log(msg) {
+            if (msg.startsWith("i18next-scanner: Unable to parse code")) {
+                Parser.prototype.log = originalLog;
+                throw new Error('Should not run into catch');
+            }
+        }
+    }
+    const parser = new ParserMock({ debug: true });
+    parser.parseFuncFromString(content, {});
+    t.same(parser.get(), {
+        en: {
+            translation: {
+                "friend": ""
+            }
+        }
+    });
+    t.end();
+});


### PR DESCRIPTION
When using trailing comma in a function within the `t` function the scanner throws an error because an empty string is passed to the esprima parser.

This PR includes a test case as well as the fix. Please let me know if you have a better idea on how to fix it or how to implement the test case.

The script is still working as expected without the fix, because the error is catched, but the it logs an error in debug mode which is first annoying and second reduces trust into the library.