### PR TITLE
Add transformDefaultValue option

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -49,6 +49,8 @@ const defaults = {
 
     defaultValue: '', // default value used if not passed to `parser.set`
 
+    transformDefaultValue: undefined,
+
     // resource
     resource: {
         // The path where resources get loaded from. Relative to current working directory.
@@ -785,7 +787,8 @@ class Parser {
             pluralFallback,
             pluralSeparator,
             defaultLng,
-            defaultValue
+            defaultValue,
+            transformDefaultValue
         } = this.options;
 
         lngs.forEach((lng) => {
@@ -889,6 +892,9 @@ class Parser {
                             resLoad[resKey] = _.isFunction(defaultValue)
                                 ? defaultValue(lng, ns, key, options)
                                 : defaultValue;
+                        }
+                        if (transformDefaultValue) {
+                            resLoad[resKey] = transformDefaultValue(resLoad[resKey]);
                         }
                         this.log(`i18next-scanner: Added a new translation key { ${chalk.yellow(JSON.stringify(resKey))}: ${chalk.yellow(JSON.stringify(resLoad[resKey]))} } to ${chalk.yellow(JSON.stringify(this.formatResourceLoadPath(lng, ns)))}`);
                     } else if (options.defaultValue && (!options.defaultValue_plural || !resKey.endsWith(`${pluralSeparator}plural`))) {


### PR DESCRIPTION
Hey there,

this PR is supposed to help with the following use case: When developing a new feature, I usually set a defaultValue right within the code (`t("key", { defaultValue: "bla" })`) which is used by i18next-scanner to populate the new keys in the resource files (`{ "key": "bla" }`). That way, the translators who will later receive the files will be able to see a sort of meaningful default message helping them with the translation. However, I'd like to make sure that we don't miss a key and accidentally ship default values. That's why I've tried prefixing the values with a marker (`{ "key": "[XXX]bla" }`) that sticks out to translators and during code review.

Correct me if I'm wrong, but I think transforming default values is not currently supported by `i18next-scanner`. I've tried passing a function to `defaultValue`:

```js
module.exports = {
  options: {
    defaultValue: (_lng, _ns, _key, options) => "[XXX]" + options.defaultValue
  }
}
```

But [`defaultValue()` is only called if no default value has been provided by `t()` itself](https://github.com/i18next/i18next-scanner/blob/master/src/parser.js#L884). Thus, it seems to me like the `defaultValue` option rather is a `fallbackDefaultValue`.

I've also tried a custom transform along the lines of this:

```js
module.exports = {
  options: {
    transform(file, enc, done) {
      const { parser } = this;
      const content = readFileSync(file.path, enc);

      parser.parseFuncFromString(content, function(key, options) {
        options.defaultValue = "[XXX]" + (options.defaultValue || "");
        parser.set(key, options);
      });

      done();
    }
  }
}
```

But again, that transformed `defaultValue` doesn't end up being used if `t()` already provides one.

Therefore, I propose adding an option `transformDefaultValue()` that allows me to do this:

```js
module.exports = {
  options: {
    transformDefaultValue: defaultValue => "[XXX]" + defaultValue
  }
}
```

I've already prepared a PR with a minimal set of changes to get your feedback. If you're not generally opposed to the idea, I'd be up for discussing the details (e.g., naming, parameters passed to `transformDefaultValue`, documentation, etc.).

**Alternative solution:** Instead of another option, it would probably be a bit cleaner to just reuse the existing `defaultValue` option and always call it (if it is a function and not a string). But I suppose that'd be a breaking change.

Thanks a lot for maintaining i18next-scanner, it's been super valuable for us!
Nicolas