### PR TITLE
Add support for dynamic context

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ Below are the configuration options with their default values:
     keySeparator: '.',
     pluralSeparator: '_',
     contextSeparator: '_',
+    contextDefaultValues: [],
     interpolation: {
         prefix: '{{',
         suffix: '}}'
@@ -744,6 +745,13 @@ Whether to add a fallback key as well as the context form key.
 Type: `String` Default: `'_'`
 
 The character to split context from key.
+
+#### contextDefaultValues
+
+Type: `Array` Default: `[]`
+
+A list of default context values, used when the scanner encounters dynamic value as a `context`.
+For a list of `['male', 'female']` the scanner will generate an entry for each value.
 
 #### plural
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -80,6 +80,7 @@ const defaults = {
     context: true, // whether to add context form key
     contextFallback: true, // whether to add a fallback key as well as the context form key
     contextSeparator: '_', // char to split context from key
+    contextDefaultValues: [], // list of values for dynamic values
 
     // Plural Form
     plural: true, // whether to add plural form key
@@ -855,6 +856,7 @@ class Parser {
             context,
             contextFallback,
             contextSeparator,
+            contextDefaultValues,
             plural,
             pluralFallback,
             pluralSeparator,
@@ -929,7 +931,10 @@ class Parser {
 
                 let contextValues = [];
                 if (containsContext) {
-                    contextValues = options.context === '' ? ['male', 'female'] : [options.context];
+                    contextValues =
+                      options.context === '' && Array.isArray(contextDefaultValues) && contextDefaultValues.length > 0
+                          ? contextDefaultValues
+                          : [options.context];
                 }
 
                 if (containsPlural) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -927,6 +927,11 @@ class Parser {
                         : !!plural;
                 })();
 
+                let contextValues = [];
+                if (containsContext) {
+                    contextValues = options.context === '' ? ['male', 'female'] : [options.context];
+                }
+
                 if (containsPlural) {
                     let suffixes = pluralFallback
                         ? this.pluralSuffixes[lng]
@@ -938,7 +943,9 @@ class Parser {
 
                     if (containsContext && containsPlural) {
                         suffixes.forEach((pluralSuffix) => {
-                            resKeys.push(`${key}${contextSeparator}${options.context}${pluralSuffix}`);
+                            contextValues.forEach(contextValue => {
+                                resKeys.push(`${key}${contextSeparator}${contextValue}${pluralSuffix}`);
+                            });
                         });
                     }
                 } else {
@@ -947,7 +954,9 @@ class Parser {
                     }
 
                     if (containsContext) {
-                        resKeys.push(`${key}${contextSeparator}${options.context}`);
+                        contextValues.forEach(contextValue => {
+                            resKeys.push(`${key}${contextSeparator}${contextValue}`);
+                        });
                     }
                 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -929,13 +929,15 @@ class Parser {
                         : !!plural;
                 })();
 
-                let contextValues = [];
-                if (containsContext) {
-                    contextValues =
-                      options.context === '' && Array.isArray(contextDefaultValues) && contextDefaultValues.length > 0
-                          ? contextDefaultValues
-                          : [options.context];
-                }
+                const contextValues = (() => {
+                    if (options.context !== '') {
+                        return [options.context];
+                    }
+                    if (ensureArray(contextDefaultValues).length > 0) {
+                        return ensureArray(contextDefaultValues);
+                    }
+                    return [];
+                })();
 
                 if (containsPlural) {
                     let suffixes = pluralFallback

--- a/test/fixtures/context-plural.js
+++ b/test/fixtures/context-plural.js
@@ -2,5 +2,9 @@ i18next.t('friend', { context: 'male', count: 1 }); // output: 'A boyfriend'
 i18next.t('friend', { context: 'female', count: 1 }); // output: 'A girlfriend'
 i18next.t('friend', { context: 'male', count: 100 }); // output: '100 boyfriends'
 i18next.t('friend', { context: 'female', count: 100 }); // output: '100 girlfriends'
+
 i18next.t('friendWithDefaultValue', '{{count}} boyfriend', { context: 'male', count: 100 }); // output: '100 boyfriends'
 i18next.t('friendWithDefaultValue', '{{count}} girlfriend', { context: 'female', count: 100 }); // output: '100 girlfriends'
+
+i18next.t('friendDynamic', { context: dynamicVal, count: 1 });
+i18next.t('friendDynamic', { context: dynamicVal, count: 100 });

--- a/test/fixtures/context.js
+++ b/test/fixtures/context.js
@@ -1,2 +1,3 @@
 i18next.t('friend', {context: 'male'}); // output: 'A boyfriend'
 i18next.t('friend', {context: 'female'}); // output: 'A girlfriend'
+i18next.t('friendDynamic', {context: dynamicVal});

--- a/test/parser.js
+++ b/test/parser.js
@@ -863,7 +863,10 @@ test('Context', (t) => {
                 translation: {
                     'friend': '',
                     'friend_male': '',
-                    'friend_female': ''
+                    'friend_female': '',
+                    'friendDynamic': '',
+                    'friendDynamic_male': '',
+                    'friendDynamic_female': '',
                 }
             }
         });
@@ -888,7 +891,10 @@ test('Context', (t) => {
             en: {
                 translation: {
                     'friend': '',
-                    'friend_male': ''
+                    'friend_male': '',
+                    'friendDynamic': '',
+                    'friendDynamic_male': '',
+                    'friendDynamic_female': '',
                 }
             }
         });
@@ -918,7 +924,13 @@ test('Context with plural combined', (t) => {
                     'friendWithDefaultValue_male': '{{count}} boyfriend',
                     'friendWithDefaultValue_male_plural': '{{count}} boyfriend',
                     'friendWithDefaultValue_female': '{{count}} girlfriend',
-                    'friendWithDefaultValue_female_plural': '{{count}} girlfriend'
+                    'friendWithDefaultValue_female_plural': '{{count}} girlfriend',
+                    'friendDynamic': '',
+                    'friendDynamic_plural': '',
+                    'friendDynamic_male': '',
+                    'friendDynamic_male_plural': '',
+                    'friendDynamic_female': '',
+                    'friendDynamic_female_plural': '',
                 }
             }
         });
@@ -939,7 +951,10 @@ test('Context with plural combined', (t) => {
                     'friend_female': '',
                     'friendWithDefaultValue': '{{count}} boyfriend',
                     'friendWithDefaultValue_male': '{{count}} boyfriend',
-                    'friendWithDefaultValue_female': '{{count}} girlfriend'
+                    'friendWithDefaultValue_female': '{{count}} girlfriend',
+                    'friendDynamic': '',
+                    'friendDynamic_male': '',
+                    'friendDynamic_female': '',
                 }
             }
         });
@@ -959,7 +974,9 @@ test('Context with plural combined', (t) => {
                     'friend_male': '',
                     'friend_female': '',
                     'friendWithDefaultValue_male': '{{count}} boyfriend',
-                    'friendWithDefaultValue_female': '{{count}} girlfriend'
+                    'friendWithDefaultValue_female': '{{count}} girlfriend',
+                    'friendDynamic_male': '',
+                    'friendDynamic_female': '',
                 }
             }
         });
@@ -978,7 +995,9 @@ test('Context with plural combined', (t) => {
                     'friend': '',
                     'friend_plural': '',
                     'friendWithDefaultValue': '{{count}} boyfriend',
-                    'friendWithDefaultValue_plural': '{{count}} boyfriend'
+                    'friendWithDefaultValue_plural': '{{count}} boyfriend',
+                    'friendDynamic': '',
+                    'friendDynamic_plural': '',
                 }
             }
         });
@@ -996,7 +1015,8 @@ test('Context with plural combined', (t) => {
             en: {
                 translation: {
                     'friend_plural': '',
-                    'friendWithDefaultValue_plural': '{{count}} boyfriend'
+                    'friendWithDefaultValue_plural': '{{count}} boyfriend',
+                    'friendDynamic_plural': '',
                 }
             }
         });

--- a/test/parser.js
+++ b/test/parser.js
@@ -865,8 +865,7 @@ test('Context', (t) => {
                     'friend_male': '',
                     'friend_female': '',
                     'friendDynamic': '',
-                    'friendDynamic_male': '',
-                    'friendDynamic_female': '',
+                    'friendDynamic_': '',
                 }
             }
         });
@@ -893,8 +892,7 @@ test('Context', (t) => {
                     'friend': '',
                     'friend_male': '',
                     'friendDynamic': '',
-                    'friendDynamic_male': '',
-                    'friendDynamic_female': '',
+                    'friendDynamic_': '',
                 }
             }
         });
@@ -908,7 +906,9 @@ test('Context with plural combined', (t) => {
     const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/context-plural.js'), 'utf-8');
 
     test('Default options', (t) => {
-        const parser = new Parser();
+        const parser = new Parser({
+            contextDefaultValues: ['male', 'female'],
+        });
         parser.parseFuncFromString(content);
         t.same(parser.get(), {
             en: {
@@ -953,8 +953,7 @@ test('Context with plural combined', (t) => {
                     'friendWithDefaultValue_male': '{{count}} boyfriend',
                     'friendWithDefaultValue_female': '{{count}} girlfriend',
                     'friendDynamic': '',
-                    'friendDynamic_male': '',
-                    'friendDynamic_female': '',
+                    'friendDynamic_': '',
                 }
             }
         });
@@ -965,6 +964,7 @@ test('Context with plural combined', (t) => {
         const parser = new Parser({
             context: true,
             contextFallback: false,
+            contextDefaultValues: ['male', 'female'],
             plural: false
         });
         parser.parseFuncFromString(content);

--- a/test/parser.js
+++ b/test/parser.js
@@ -865,7 +865,6 @@ test('Context', (t) => {
                     'friend_male': '',
                     'friend_female': '',
                     'friendDynamic': '',
-                    'friendDynamic_': '',
                 }
             }
         });
@@ -892,7 +891,6 @@ test('Context', (t) => {
                     'friend': '',
                     'friend_male': '',
                     'friendDynamic': '',
-                    'friendDynamic_': '',
                 }
             }
         });
@@ -953,7 +951,6 @@ test('Context with plural combined', (t) => {
                     'friendWithDefaultValue_male': '{{count}} boyfriend',
                     'friendWithDefaultValue_female': '{{count}} girlfriend',
                     'friendDynamic': '',
-                    'friendDynamic_': '',
                 }
             }
         });


### PR DESCRIPTION
This allows scanner to add a proper values for `context` when it is a dynamic values => both of the values (`male`, `female`) should be in the translation file.

Closes https://github.com/i18next/i18next-scanner/issues/176