### PR TITLE
False ns type error when parsing <Trans ns="...">

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -595,7 +595,7 @@ class Parser {
             }
 
             if (Object.prototype.hasOwnProperty.call(attr, 'ns')) {
-                if (typeof options.ns !== 'string') {
+                if (typeof attr.ns !== 'string') {
                     this.log(`The ns attribute must be a string, saw ${chalk.yellow(attr.ns)}`);
                 }
 


### PR DESCRIPTION
Hi, I've got false error when parsing `Trans` with `ns` attributre.

I think it should be `attr.ns` for testing the type not `options.ns`