### PR TITLE
Print the literal code nodes-to-string is choking on

### DIFF
--- a/src/nodes-to-string.js
+++ b/src/nodes-to-string.js
@@ -32,7 +32,7 @@ const isObjectExpression = (node) => {
     return node.type === 'ObjectExpression';
 };
 
-const nodesToString = (nodes) => {
+const nodesToString = (nodes, code) => {
     let memo = '';
     let nodeIndex = 0;
     nodes.forEach((node, i) => {
@@ -58,10 +58,11 @@ const nodesToString = (nodes) => {
                 memo += `<${nodeIndex}>{{${expression.properties[0].key.name}}}</${nodeIndex}>`;
             } else {
                 console.error(`Unsupported JSX expression. Only static values or {{interpolation}} blocks are supported. Got ${expression.type}:`);
+                console.error(code.slice(node.start, node.end));
                 console.error(node.expression);
             }
         } else if (node.children) {
-            memo += `<${nodeIndex}>${nodesToString(node.children)}</${nodeIndex}>`;
+            memo += `<${nodeIndex}>${nodesToString(node.children, code)}</${nodeIndex}>`;
         }
 
         ++nodeIndex;

--- a/src/parser.js
+++ b/src/parser.js
@@ -492,7 +492,7 @@ class Parser {
             acorn: acornOptions = this.options.trans.acorn, // object
         } = { ...opts };
 
-        const parseJSXElement = (node) => {
+        const parseJSXElement = (node, code) => {
             if (!node) {
                 return;
             }
@@ -509,12 +509,12 @@ class Parser {
                     return;
                 }
 
-                parseJSXElement(expression);
+                parseJSXElement(expression, code);
             });
 
             ensureArray(node.children).forEach(childNode => {
                 if (childNode.type === 'JSXElement') {
-                    parseJSXElement(childNode);
+                    parseJSXElement(childNode, code);
                 }
             });
 
@@ -586,7 +586,7 @@ class Parser {
             const tOptions = attr.tOptions;
             const options = {
                 ...tOptions,
-                defaultValue: defaultsString || nodesToString(node.children),
+                defaultValue: defaultsString || nodesToString(node.children, code),
                 fallbackKey: fallbackKey || this.options.trans.fallbackKey
             };
 
@@ -618,7 +618,7 @@ class Parser {
                 });
 
             jsxwalk(ast, {
-                JSXElement: parseJSXElement
+                JSXElement: node => parseJSXElement(node, content)
             });
         } catch (err) {
             if (transformOptions.filepath) {

--- a/test/jsx-parser.js
+++ b/test/jsx-parser.js
@@ -14,7 +14,7 @@ const jsxToString = (code) => {
             return '';
         }
 
-        return nodesToString(nodes);
+        return nodesToString(nodes, code);
     } catch (e) {
         console.error(e);
         return '';


### PR DESCRIPTION
This is a really dumb edit -- just pass down the content we're parsing from the top and do a slice (so as not to modify the original) on it. I was finding it challenging to read the AST and figure out what/where was breaking. With this, I can at least to a search in my package for the string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added

```

 PASS  test/jsx-parser.js 5 OK 44.865ms
test/parser.js 2> i18next-scanner: "none" does not exist in the namespaces (["translation"]): key="key2", options={}
 PASS  test/parser.js 69 OK 944.745ms
test/transform-stream.js 2> (node:97914) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
 PASS  test/transform-stream.js 55 OK 736.272ms

                         
  🌈 SUMMARY RESULTS 🌈  
                         

Suites:   3 passed, 3 of 3 completed
Asserts:  129 passed, of 129
Time:     8s
------------------------|----------|----------|----------|----------|-------------------|
File                    |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------------|----------|----------|----------|----------|-------------------|
All files               |    91.68 |    88.08 |    98.68 |    91.27 |                   |
 acorn-jsx-walk.js      |      100 |       50 |    85.71 |      100 |              7,21 |
 flatten-object-keys.js |      100 |       90 |      100 |      100 |                22 |
 index.js               |    98.44 |      100 |      100 |    98.39 |                96 |
 nodes-to-string.js     |     81.4 |       75 |      100 |    80.95 |... 29,54,60,61,62 |
 omit-empty-object.js   |      100 |    83.33 |      100 |      100 |                25 |
 parser.js              |    91.01 |    88.92 |      100 |    90.48 |... 60,762,763,848 |
------------------------|----------|----------|----------|----------|-------------------|
```