### PR TITLE
feat: allow loadPath and savePath on resource configuration to be functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,11 +690,36 @@ Resource options:
 ```js
 { // Default
     resource: {
-        // The path where resources get loaded from. Relative to current working directory.
+        // The path where resources get loaded from. Relative to current working directory. 
         loadPath: 'i18n/{{lng}}/{{ns}}.json',
 
         // The path to store resources. Relative to the path specified by `gulp.dest(path)`.
         savePath: 'i18n/{{lng}}/{{ns}}.json',
+
+        // Specify the number of space characters to use as white space to insert into the output JSON string for readability purpose.
+        jsonIndent: 2,
+
+        // Normalize line endings to '\r\n', '\r', '\n', or 'auto' for the current operating system. Defaults to '\n'.
+        // Aliases: 'CRLF', 'CR', 'LF', 'crlf', 'cr', 'lf'
+        lineEnding: '\n'
+    }
+}
+```
+
+`loadPath` and `savePath` can be both be defined as `Function` with parameters `lng` and `ns`
+
+```js
+{ // Default
+    resource: {
+        // The path where resources get loaded from. Relative to current working directory. 
+        loadPath: function(lng, ns) {
+            return 'i18n/'+lng+'/'+ns+'.json';
+        },
+
+        // The path to store resources. Relative to the path specified by `gulp.dest(path)`.
+        savePath: function(lng, ns) {
+            return 'i18n/'+lng+'/'+ns+'.json';
+        },
 
         // Specify the number of space characters to use as white space to insert into the output JSON string for readability purpose.
         jsonIndent: 2,

--- a/src/parser.js
+++ b/src/parser.js
@@ -309,9 +309,11 @@ class Parser {
             ns: new RegExp(_.escapeRegExp(options.interpolation.prefix + 'ns' + options.interpolation.suffix), 'g')
         };
 
-        return options.resource.loadPath
-            .replace(regex.lng, lng)
-            .replace(regex.ns, ns);
+        return _.isFunction(options.resource.loadPath)
+            ? options.resource.loadPath(lng, ns)
+            : options.resource.loadPath
+                .replace(regex.lng, lng)
+                .replace(regex.ns, ns);
     }
 
     formatResourceSavePath(lng, ns) {
@@ -321,9 +323,11 @@ class Parser {
             ns: new RegExp(_.escapeRegExp(options.interpolation.prefix + 'ns' + options.interpolation.suffix), 'g')
         };
 
-        return options.resource.savePath
-            .replace(regex.lng, lng)
-            .replace(regex.ns, ns);
+        return _.isFunction(options.resource.savePath)
+            ? options.resource.savePath(lng, ns)
+            : options.resource.savePath
+                .replace(regex.lng, lng)
+                .replace(regex.ns, ns);
     }
 
     fixStringAfterRegExp(strToFix) {

--- a/test/transform-stream.js
+++ b/test/transform-stream.js
@@ -695,3 +695,69 @@ test('Line Endings', function(t) {
 
     t.end();
 });
+
+test('resource.loadPath and resource.savePath configuration as functions', function(t) {
+    const options = _.merge({}, defaults, {
+        removeUnusedKeys: true,
+        resource: {
+            loadPath: function(lng, ns) {
+                return 'test/fixtures/i18n/'+lng+'/'+ns+'.json';
+            },
+            savePath: function(lng, ns) {
+                return 'i18n/'+lng+'/'+ns+'.json';
+            }
+        }
+    });
+
+    gulp.src('test/fixtures/modules/**/*.js')
+        .pipe(scanner(options))
+        .on('end', function() {
+            t.end();
+        })
+        .pipe(tap(function(file) {
+            const contents = file.contents.toString();
+
+            // English - locale.json
+            if (file.path === 'i18n/en/locale.json') {
+                const found = JSON.parse(contents);
+                const wanted = {};
+                t.same(found, wanted);
+            }
+
+            // English - resource.json
+            if (file.path === 'i18n/en/resource.json') {
+                const found = JSON.parse(contents);
+                const wanted = {
+                    "Loading...": "Loading...", // Note. This is an existing translation key in English resource file.
+                    "This value does not exist.": "__STRING_NOT_TRANSLATED__",
+                    "YouTube has more than {{count}} billion users.": "__STRING_NOT_TRANSLATED__",
+                    "YouTube has more than {{count}} billion users._plural": "__STRING_NOT_TRANSLATED__",
+                    "You have {{count}} messages.": "__STRING_NOT_TRANSLATED__",
+                    "You have {{count}} messages._plural": "__STRING_NOT_TRANSLATED__"
+                };
+                t.same(found, wanted);
+            }
+
+            // German - locale.json
+            if (file.path === 'i18n/de/locale.json') {
+                const found = JSON.parse(contents);
+                const wanted = {};
+                t.same(found, wanted);
+            }
+
+            // German - resource.json
+            if (file.path === 'i18n/de/resource.json') {
+                const found = JSON.parse(contents);
+                const wanted = {
+                    "Loading...": "__STRING_NOT_TRANSLATED__",
+                    "This value does not exist.": "__STRING_NOT_TRANSLATED__",
+                    "YouTube has more than {{count}} billion users.": "__STRING_NOT_TRANSLATED__",
+                    "YouTube has more than {{count}} billion users._plural": "__STRING_NOT_TRANSLATED__",
+                    "You have {{count}} messages.": "__STRING_NOT_TRANSLATED__",
+                    "You have {{count}} messages._plural": "__STRING_NOT_TRANSLATED__"
+                };
+                t.same(found, wanted);
+            }
+        }));
+});
+


### PR DESCRIPTION
To allow loadPath and savePath on the resource configuration to be functions so you can have separated language stores. Usable if working with plugins and want to keep language translations separated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ X] only relevant code is changed (make a diff before you submit the PR)
- [ X] run tests `npm run test`
- [X ] tests are included
- [ X] documentation is changed or added