### PR TITLE
fix: enforce i18next JSON v3 to maintain backward compatibility (#217)

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,10 @@ import flattenObjectKeys from './flatten-object-keys';
 import omitEmptyObject from './omit-empty-object';
 import nodesToString from './nodes-to-string';
 
+i18next.init({
+  compatibilityJSON: 'v3',
+});
+
 const defaults = {
     debug: false, // verbose logging
 
@@ -1018,7 +1022,5 @@ class Parser {
         return JSON.stringify(this.get(others), replacer, space);
     }
 }
-
-i18next.init();
 
 export default Parser;


### PR DESCRIPTION
There is a breaking change introduced in v21.0 that `compatibilityJSON` is set to 'v4':
https://www.i18next.com/misc/migration-guide#v-20-x-x-to-v-21-0-0

To enforce old behaviour, this PR enables `compatibilityJSON = 'v3'` on `i18next.init` call to maintain backward compability.

#### i18next JSON v4
https://www.i18next.com/misc/json-format#i18next-json-v4

#### i18next JSON v3
https://www.i18next.com/misc/json-format#i18next-json-v3