### PR TITLE
chore: use let instead of const to fix type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ const customHandler = function(key) {
 };
 
 const parser = new Parser();
-const content = '';
+let content = '';
 
 // Parse Translation Function
 // i18next.t('key');


### PR DESCRIPTION
`content` variable is going to be re-assigned, so if we use `const`, we're going to get the following error:

"Uncaught TypeError: Assignment to constant variable."

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided