### PR TITLE
Update conflicting default translation message

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,6 +1,5 @@
 /* eslint no-console: 0 */
 /* eslint no-eval: 0 */
-import fs from 'fs';
 import * as acorn from 'acorn';
 import acornJsx from 'acorn-jsx';
 import acornStage3 from 'acorn-stage3';
@@ -9,14 +8,15 @@ import cloneDeep from 'clone-deep';
 import deepMerge from 'deepmerge';
 import { ensureArray } from 'ensure-type';
 import { parse } from 'esprima-next';
+import fs from 'fs';
+import i18next from 'i18next';
 import _ from 'lodash';
 import parse5 from 'parse5';
 import sortObject from 'sortobject';
-import i18next from 'i18next';
 import jsxwalk from './acorn-jsx-walk';
 import flattenObjectKeys from './flatten-object-keys';
-import omitEmptyObject from './omit-empty-object';
 import nodesToString from './nodes-to-string';
+import omitEmptyObject from './omit-empty-object';
 
 i18next.init({
   compatibilityJSON: 'v3',
@@ -1046,7 +1046,7 @@ class Parser {
               resLoad[resKey] = options.defaultValue;
             } else if ((resLoad[resKey] !== options.defaultValue) && (lng === defaultLng)) {
               // A default value has provided but it's different with the expected default
-              this.log(`The translation key ${chalk.yellow(JSON.stringify(resKey))} has a different default value, you may need to check the translation key of default language (${defaultLng})`);
+              this.log(`The translation key ${chalk.yellow(JSON.stringify(resKey))}, with a default value of "${chalk.yellow(options.defaultValue)}" has a different default value, you may need to check the translation key of default language (${defaultLng})`);
             }
           } else if (options.defaultValue_plural && resKey.endsWith(`${pluralSeparator}plural`)) {
             if (!resLoad[resKey]) {
@@ -1054,7 +1054,7 @@ class Parser {
               resLoad[resKey] = options.defaultValue_plural;
             } else if ((resLoad[resKey] !== options.defaultValue_plural) && (lng === defaultLng)) {
               // A default value has provided but it's different with the expected default
-              this.log(`The translation key ${chalk.yellow(JSON.stringify(resKey))} has a different default value, you may need to check the translation key of default language (${defaultLng})`);
+              this.log(`The translation key ${chalk.yellow(JSON.stringify(resKey))}, with a default value of "${chalk.yellow(options.defaultValue_plural)}" has a different default value, you may need to check the translation key of default language (${defaultLng})`);
             }
           }
 


### PR DESCRIPTION
This updates the terminal messaging when a conflicting default translation has a mismatch with the translation in the default language json file to include the default message. This is to make it easier to locate which translation is conflicting as there is a chance that there are numerous keys sharing the same name at a deeper level e.g.

```
"user": {
  "button": {
    "tooltip": "User tooltip"
  },
},
"admin": {
  "button": {
    "tooltip": "Admin tooltip"
  },
},
"placeholder": {
  "button": {
    "tooltip": "Placeholder tooltip"
  },
},
```

Before this would output that the key `tooltip` had a conflict, which in larger translation files becomes very difficult to track down.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Test coverage

<img width="916" alt="Screenshot 2022-10-14 at 12 48 28" src="https://user-images.githubusercontent.com/39883696/195840388-f46f607f-19a5-4ccb-aaa7-ccf5e61e7515.png">

#### New output

<img width="1381" alt="Screenshot 2022-10-14 at 12 54 42" src="https://user-images.githubusercontent.com/39883696/195840949-1413e049-acf8-4068-89f9-9d20ea4f9992.png">

