### PR TITLE
Fix array duplication after parse

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -774,7 +774,8 @@ class Parser {
     let resStore = {};
     if (this.options.removeUnusedKeys) {
       // Merge two objects `resStore` and `resScan` deeply, returning a new merged object with the elements from both `resStore` and `resScan`.
-      const resMerged = deepMerge(this.resStore, this.resScan);
+      const overwriteMerge = (destinationArray, sourceArray, options) => sourceArray;
+      const resMerged = deepMerge(this.resStore, this.resScan, { arrayMerge: overwriteMerge });
 
       Object.keys(this.resStore).forEach((lng) => {
         Object.keys(this.resStore[lng]).forEach((ns) => {


### PR DESCRIPTION
This fixes #156 and #168.

I'm just using the suggested fix for deepMerge.