### PR TITLE
fix: do not show log message when defaultValue returns undefined

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1040,7 +1040,9 @@ class Parser {
                 ? defaultValue(lng, ns, key, options)
                 : (options.defaultValue || defaultValue);
             }
-            this.log(`Added a new translation key { ${chalk.yellow(JSON.stringify(resKey))}: ${chalk.yellow(JSON.stringify(resLoad[resKey]))} } to ${chalk.yellow(JSON.stringify(this.formatResourceLoadPath(lng, ns)))}`);
+            if (resLoad[resKey] !== undefined) {
+              this.log(`Added a new translation key { ${chalk.yellow(JSON.stringify(resKey))}: ${chalk.yellow(JSON.stringify(resLoad[resKey]))} } to ${chalk.yellow(JSON.stringify(this.formatResourceLoadPath(lng, ns)))}`);
+            }
           } else if (options.defaultValue && (!options.defaultValue_plural || !resKey.endsWith(`${pluralSeparator}plural`))) {
             if (!resLoad[resKey]) {
               // Use `options.defaultValue` if specified


### PR DESCRIPTION
Do not show log message when defaultValue returns undefined because in this case no translation key is added

Fixes https://github.com/i18next/i18next-scanner/issues/245

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)