### PR TITLE
feat: add notComments

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -17,6 +17,7 @@ import jsxwalk from './acorn-jsx-walk';
 import flattenObjectKeys from './flatten-object-keys';
 import nodesToString from './nodes-to-string';
 import omitEmptyObject from './omit-empty-object';
+import { removeComments } from './util';
 
 i18next.init({
   compatibilityJSON: 'v3',
@@ -433,6 +434,7 @@ class Parser {
       opts = {};
     }
 
+    const trimmedContent = this.options.notComments ? removeComments(content) : content;   
     const funcs = (opts.list !== undefined)
       ? ensureArray(opts.list)
       : ensureArray(this.options.func.list);
@@ -466,7 +468,7 @@ class Parser {
     const re = new RegExp(pattern, 'gim');
 
     let r;
-    while ((r = re.exec(content))) {
+    while ((r = re.exec(trimmedContent))) {
       const options = {};
       const full = r[0];
 
@@ -487,7 +489,7 @@ class Parser {
       if (endsWithComma) {
         const { propsFilter } = { ...opts };
 
-        let code = matchBalancedParentheses(content.substr(re.lastIndex));
+        let code = matchBalancedParentheses(trimmedContent.substr(re.lastIndex));
 
         if (typeof propsFilter === 'function') {
           code = propsFilter(code);

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,6 @@
+export const removeComments = (code) => {
+  code = code.replace(/\/\/.*$/gm, "");
+  code = code.replace(/\/\*[\s\S]*?\*\//gm, "");
+  code = code.replace(/\/\*\*[\s\S]*?\*\//gm, "");
+  return code;
+};


### PR DESCRIPTION
hi,I have found that the content in the comments has also been processed, which I believe is an unnecessary cost. I may prefer to support configuration. So I added the notComments feature。「 'pnpm i18next-scanner',  It's my way of using it」

before submitting, I conducted unit testing for the current project. no problem

if you need to add anything else, please remind me

I know there may be some minor issues, eg:  i18next.t('//xxx')

But I think this type of situation is very, very rare, and if possible, we can explain the problem in advance. I think using regular expression is the least costly, and I found some people in Issues who also want to support this feature

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests npm run test
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
