### PR TITLE
refactor: remove the traverse code in `parseJSXElement` to eliminate redundant calls for setting translation keys

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -555,27 +555,6 @@ class Parser {
         return;
       }
 
-      ensureArray(node.openingElement.attributes).forEach(attribute => {
-        const value = attribute.value;
-
-        if (!(value && value.type === 'JSXExpressionContainer')) {
-          return;
-        }
-
-        const expression = value.expression;
-        if (!(expression && expression.type === 'JSXElement')) {
-          return;
-        }
-
-        parseJSXElement(expression, code);
-      });
-
-      ensureArray(node.children).forEach(childNode => {
-        if (childNode.type === 'JSXElement') {
-          parseJSXElement(childNode, code);
-        }
-      });
-
       if (component instanceof RegExp
         ? !node.openingElement.name.name.match(component)
         : node.openingElement.name.name !== component) {


### PR DESCRIPTION
This PR removes the traverse code in `parseJSXElement` to eliminate redundant calls for setting translation keys. The functionality is now handled by the `acorn-jsxwalk` library, which allows for traversing all `JSXElement` nodes seamlessly.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)