### PR TITLE
Support new plural suffixes with JSON v4 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ into resource files
 {
   "Loading...": "Wird geladen...", // uses existing translation
   "Backslashes in single quote: ' \\ '": "__NOT_TRANSLATED__", // returns a custom string
-  "This is a multiline string": "this is a multiline string", // returns the key as the default value 
+  "This is a multiline string": "this is a multiline string", // returns the key as the default value
   "car": "car",
   "car_blue": "One blue car",
   "car_blue_plural": "{{count}} blue cars",
@@ -263,7 +263,7 @@ gulp.task('i18next', function() {
             resource: {
                 // the source path is relative to current working directory
                 loadPath: 'assets/i18n/{{lng}}/{{ns}}.json',
-                
+
                 // the destination path is relative to your `gulp.dest()` path
                 savePath: 'i18n/{{lng}}/{{ns}}.json'
             }
@@ -307,7 +307,7 @@ const Parser = require('i18next-scanner').Parser;
 const parser = new Parser(options);
 
 const code = "i18next.t('key'); ...";
-parser.parseFuncFromString(code); 
+parser.parseFuncFromString(code);
 
 const jsx = '<Trans i18nKey="some.key">Default text</Trans>';
 parser.parseTransFromString(jsx);
@@ -381,7 +381,7 @@ Get the value of a translation key or the whole i18n resource store
 // Returns the whole i18n resource store
 parser.get();
 
-// Returns the resource store with the top-level keys sorted by alphabetical order 
+// Returns the resource store with the top-level keys sorted by alphabetical order
 parser.get({ sort: true });
 
 // Returns a value in fallback language (@see options.fallbackLng) with namespace and key
@@ -438,12 +438,12 @@ For example:
 const customTransform = function _transform(file, enc, done) {
     const parser = this.parser;
     const content = fs.readFileSync(file.path, enc);
-    
+
     parser.parseFuncFromString(content, { list: ['i18n.t'] }, function(key) {
         const defaultValue = '__L10N__';
         parser.set(key, defaultValue);
     });
-    
+
     done();
 };
 ```
@@ -455,13 +455,13 @@ const hash = require('sha1');
 const customTransform = function _transform(file, enc, done) {
     const parser = this.parser;
     const content = fs.readFileSync(file.path, enc);
-    
+
     parser.parseFuncFromString(content, { list: ['i18n._'] }, function(key) {
         const value = key;
         const defaultKey = hash(value);
         parser.set(defaultKey, value);
     });
-    
+
     done();
 };
 ```
@@ -484,7 +484,7 @@ const customFlush = function _flush(done) {
             // add your code
         });
     });
-    
+
     done();
 };
 
@@ -542,6 +542,7 @@ Below are the configuration options with their default values:
     nsSeparator: ':',
     keySeparator: '.',
     pluralSeparator: '_',
+    pluralVersion: null,
     contextSeparator: '_',
     contextDefaultValues: [],
     interpolation: {
@@ -724,7 +725,7 @@ Resource options:
 ```js
 { // Default
     resource: {
-        // The path where resources get loaded from. Relative to current working directory. 
+        // The path where resources get loaded from. Relative to current working directory.
         loadPath: 'i18n/{{lng}}/{{ns}}.json',
 
         // The path to store resources. Relative to the path specified by `gulp.dest(path)`.
@@ -745,7 +746,7 @@ Resource options:
 ```js
 { // Default
     resource: {
-        // The path where resources get loaded from. Relative to current working directory. 
+        // The path where resources get loaded from. Relative to current working directory.
         loadPath: function(lng, ns) {
             return 'i18n/'+lng+'/'+ns+'.json';
         },
@@ -836,6 +837,12 @@ Type: `String` Default: `'_'`
 
 The character to split plural from key.
 
+#### pluralVersion
+
+Type: `String` Default: `null`
+
+The `compatibilityJSON` version to use for plural suffixes.
+
 #### interpolation
 
 Type: `Object`
@@ -857,7 +864,7 @@ interpolation options
 
 Type: `Object` Default: `{}`
 
-This can be used to pass any additional information regarding the string. 
+This can be used to pass any additional information regarding the string.
 
 #### allowDynamicKeys
 

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Below are the configuration options with their default values:
 
 ```javascript
 {
+    compatibilityJSON: 'v3', // One of: 'v1', 'v2', 'v3', 'v4
     debug: false,
     removeUnusedKeys: false,
     sort: false,
@@ -542,7 +543,6 @@ Below are the configuration options with their default values:
     nsSeparator: ':',
     keySeparator: '.',
     pluralSeparator: '_',
-    pluralVersion: null,
     contextSeparator: '_',
     contextDefaultValues: [],
     interpolation: {
@@ -553,6 +553,14 @@ Below are the configuration options with their default values:
     allowDynamicKeys: false,
 }
 ```
+
+#### compatibilityJSON
+
+Type: `String` Default: `'v3'`
+
+The `compatibilityJSON` version to use for plural suffixes.
+
+See https://https://www.i18next.com/misc/json-format for details.
 
 #### debug
 
@@ -836,12 +844,6 @@ Whether to add a fallback key as well as the plural form key.
 Type: `String` Default: `'_'`
 
 The character to split plural from key.
-
-#### pluralVersion
-
-Type: `String` Default: `null`
-
-The `compatibilityJSON` version to use for plural suffixes.
 
 #### interpolation
 

--- a/examples/i18next-scanner.config.js
+++ b/examples/i18next-scanner.config.js
@@ -11,6 +11,7 @@ module.exports = {
     ],
     output: './',
     options: {
+        compatibilityJSON: 'v3',
         debug: true,
         func: {
             list: ['i18next.t', 'i18n.t'],

--- a/src/parser.js
+++ b/src/parser.js
@@ -92,6 +92,7 @@ const defaults = {
   plural: true, // whether to add plural form key
   pluralFallback: true, // whether to add a fallback key as well as the plural form key
   pluralSeparator: '_', // char to split plural from key
+  pluralVersion: null, // 'compatibilityJSON' version for plural suffixes
 
   // interpolation options
   interpolation: {
@@ -272,6 +273,12 @@ class Parser {
       ...options
     });
 
+    const i18nextInstance = i18next.createInstance();
+    i18nextInstance.init({
+      compatibilityJSON: this.options.pluralVersion || 'v3',
+      pluralSeparator: this.options.pluralSeparator,
+    });
+
     const lngs = this.options.lngs;
     const namespaces = this.options.ns;
 
@@ -279,7 +286,11 @@ class Parser {
       this.resStore[lng] = this.resStore[lng] || {};
       this.resScan[lng] = this.resScan[lng] || {};
 
-      this.pluralSuffixes[lng] = ensureArray(getPluralSuffixes(lng, this.options.pluralSeparator));
+      if (this.options.pluralVersion) {
+        this.pluralSuffixes[lng] = i18nextInstance.services.pluralResolver.getSuffixes(lng);
+      } else {
+        this.pluralSuffixes[lng] = ensureArray(getPluralSuffixes(lng, this.options.pluralSeparator));
+      }
       if (this.pluralSuffixes[lng].length === 0) {
         this.log(`No plural rule found for: ${lng}`);
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,11 +18,9 @@ import flattenObjectKeys from './flatten-object-keys';
 import nodesToString from './nodes-to-string';
 import omitEmptyObject from './omit-empty-object';
 
-i18next.init({
-  compatibilityJSON: 'v3',
-});
-
 const defaults = {
+  compatibilityJSON: 'v3', // JSON format
+
   debug: false, // verbose logging
 
   sort: false, // sort keys in alphabetical order
@@ -92,7 +90,6 @@ const defaults = {
   plural: true, // whether to add plural form key
   pluralFallback: true, // whether to add a fallback key as well as the plural form key
   pluralSeparator: '_', // char to split plural from key
-  pluralVersion: null, // 'compatibilityJSON' version for plural suffixes
 
   // interpolation options
   interpolation: {
@@ -225,32 +222,6 @@ const normalizeOptions = (options) => {
   return options;
 };
 
-// Get an array of plural suffixes for a given language.
-// @param {string} lng The language.
-// @param {string} pluralSeparator pluralSeparator, default '_'.
-// @return {array} An array of plural suffixes.
-const getPluralSuffixes = (lng, pluralSeparator = '_') => {
-  const rule = i18next.services.pluralResolver.getRule(lng);
-
-  if (!(rule && rule.numbers)) {
-    return []; // Return an empty array if lng is not supported
-  }
-
-  if (rule.numbers.length === 1) {
-    return [`${pluralSeparator}0`];
-  }
-
-  if (rule.numbers.length === 2) {
-    return ['', `${pluralSeparator}plural`];
-  }
-
-  const suffixes = rule.numbers.reduce((acc, n, i) => {
-    return acc.concat(`${pluralSeparator}${i}`);
-  }, []);
-
-  return suffixes;
-};
-
 /**
 * Creates a new parser
 * @constructor
@@ -275,7 +246,7 @@ class Parser {
 
     const i18nextInstance = i18next.createInstance();
     i18nextInstance.init({
-      compatibilityJSON: this.options.pluralVersion || 'v3',
+      compatibilityJSON: this.options.compatibilityJSON,
       pluralSeparator: this.options.pluralSeparator,
     });
 
@@ -286,11 +257,8 @@ class Parser {
       this.resStore[lng] = this.resStore[lng] || {};
       this.resScan[lng] = this.resScan[lng] || {};
 
-      if (this.options.pluralVersion) {
-        this.pluralSuffixes[lng] = i18nextInstance.services.pluralResolver.getSuffixes(lng);
-      } else {
-        this.pluralSuffixes[lng] = ensureArray(getPluralSuffixes(lng, this.options.pluralSeparator));
-      }
+      this.pluralSuffixes[lng] = i18nextInstance.services.pluralResolver.getSuffixes(lng);
+
       if (this.pluralSuffixes[lng].length === 0) {
         this.log(`No plural rule found for: ${lng}`);
       }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -793,8 +793,8 @@ describe('Plural', () => {
 
   test('pluralVersion', () => {
     const parser = new Parser({
+      compatibilityJSON: 'v4',
       lngs: ['en'],
-      pluralVersion: 'v4'
     });
     const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/plural.js'), 'utf-8');
     parser.parseFuncFromString(content, { propsFilter: props => props });

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -791,6 +791,33 @@ describe('Plural', () => {
     });
   });
 
+  test('pluralVersion', () => {
+    const parser = new Parser({
+      lngs: ['en'],
+      pluralVersion: 'v4'
+    });
+    const content = fs.readFileSync(path.resolve(__dirname, 'fixtures/plural.js'), 'utf-8');
+    parser.parseFuncFromString(content, { propsFilter: props => props });
+    expect(parser.get()).toEqual({
+      en: {
+        translation: {
+          'key_one': '',
+          'key_other': '',
+          'keyWithCount_one': '',
+          'keyWithCount_other': '',
+          'keyWithVariable_one': '',
+          'keyWithVariable_other': '',
+          'keyWithCountAndDefaultValues_one': '{{count}} item',
+          'keyWithCountAndDefaultValues_other': '{{count}} item',
+          'keyWithDefaultValueAndCount_one': '{{count}} item',
+          'keyWithDefaultValueAndCount_other': '{{count}} item',
+          'keyWithDefaultValueAndVariable_one': '{{count}} item',
+          'keyWithDefaultValueAndVariable_other': '{{count}} item',
+        }
+      }
+    });
+  });
+
   test('User defined function', () => {
     const parser = new Parser({
       plural: (lng, ns, key, options) => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -791,7 +791,7 @@ describe('Plural', () => {
     });
   });
 
-  test('pluralVersion', () => {
+  test('compatibilityJSON', () => {
     const parser = new Parser({
       compatibilityJSON: 'v4',
       lngs: ['en'],


### PR DESCRIPTION
Fixes gh-228

Supports new plural suffixes via a new option `pluralVersion` which specifies the `compatibilityJSON` version to use for pluralization. Default behavior remains unchanged.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
